### PR TITLE
Add workflow to run tests on all OS & Python

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,84 @@
+# Run tests on Windows, Linux, and Mac
+#
+# NOTE: Pin actions to a specific commit to avoid having the authentication
+# token stolen if the Action is compromised. See the comments and links here:
+# https://github.com/pypa/gh-action-pypi-publish/issues/27
+#
+name: test
+
+# Only build PRs, the master main, and releases. Pushes to branches will only
+# be built when a PR is opened. This avoids duplicated buids in PRs comming
+# from branches in the origin repository (1 for PR and 1 for push).
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  release:
+    types:
+      - published
+
+# Use bash by default in all jobs
+defaults:
+  run:
+    shell: bash
+
+jobs:
+
+  #############################################################################
+  # Run tests
+  test:
+    name: ${{ matrix.os }} py${{ matrix.python }} ${{ matrix.dependencies }}
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      # Otherwise, the workflow would stop if a single job fails. We want to
+      # run all of them to catch failures in different combinations.
+      fail-fast: false
+      matrix:
+        os: [ubuntu, macos, windows]
+        python: ["3.6", "3.9", "3.10-dev"]
+    env:
+      OS: ${{ matrix.os }}
+      PYTHON: ${{ matrix.python }}
+
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          # Need to fetch more than the last commit so that setuptools-scm can
+          # create the correct version string. If the number of commits since
+          # the last release is greater than this, the version still be wrong.
+          # Increase if necessary.
+          fetch-depth: 100
+          # The GitHub token is preserved by default but this job doesn't need
+          # to be able to push to GitHub.
+          persist-credentials: false
+
+      # Need the tags so that setuptools-scm can form a valid version number
+      - name: Fetch git tags
+        run: git fetch origin 'refs/tags/*:refs/tags/*'
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ env.PYTHON }}
+
+      - name: Install build requirements
+        run: python -m pip install twine setuptools_scm wheel
+
+      - name: Build source and wheel distributions
+        run: |
+          python setup.py sdist bdist_wheel
+          echo ""
+          echo "Generated files:"
+          ls -lh dist/
+
+      - name: Install the package and requirements
+        run: python -m pip install `ls dist/*.whl`[jupyter]
+
+      - name: List installed packages
+        run: pip freeze
+
+      - name: Build the documentation
+        run: cd doc && nene

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
-        python: ["3.6", "3.9", "3.10-dev"]
+        python: ["3.7", "3.9", "3.10-dev"]
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
-        python: ["3.7", "3.9", "3.10-dev"]
+        python: ["3.6", "3.9", "3.10-dev"]
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python }}

--- a/nene/cli.py
+++ b/nene/cli.py
@@ -145,8 +145,8 @@ def main(config, serve, verbose):
                 console.print(f"   {page['source']}:")
                 for datum in data[page["parent"]]:
                     console.print(f"     ↳ {datum['source']}")
-                    # Use | to make sure keys already in page aren't overwritten
-                    page.update(datum["content"] | page)
+                    # Merge the two data dictionaries with 'page' taking precedence
+                    page.update({**datum["content"], **page})
     else:
         console.print("   There wasn't any :disappointed:")
 

--- a/nene/cli.py
+++ b/nene/cli.py
@@ -180,7 +180,7 @@ def main(config, serve, verbose):
         destination = output / Path(page["path"])
         console.print(f"   {str(destination)} ⇒  id: [bold green]{page['id']}[/]")
         destination.parent.mkdir(parents=True, exist_ok=True)
-        destination.write_text(rendered_html[identifier])
+        destination.write_text(rendered_html[identifier], encoding="utf-8")
 
     console.print(":bar_chart: [b]Writing Jupyter Notebook image files:[/b]")
     if tree["ipynb"]:

--- a/nene/core.py
+++ b/nene/core.py
@@ -343,7 +343,9 @@ def markdown_to_html(page, jinja_env, config, site, build):
 
     """
     if page["source"].endswith(".md"):
-        template = jinja_env.get_template(page["source"])
+        # Jinja doesn't allow \ as paths even on Windows
+        # https://github.com/pallets/jinja/issues/711
+        template = jinja_env.get_template(str(page["source"]).replace("\\", "/"))
         markdown = template.render(page=page, config=config, site=site, build=build)
     else:
         markdown = page["markdown"]

--- a/nene/core.py
+++ b/nene/core.py
@@ -73,7 +73,7 @@ def parse_data_file(path):
     path = Path(path)
     suffix = path.suffix
     loader = {".yml": yaml.safe_load, ".yaml": yaml.safe_load, ".json": json.loads}
-    data = loader[suffix](path.read_text())
+    data = loader[suffix](path.read_text(encoding="utf-8"))
     return data
 
 
@@ -246,7 +246,7 @@ def load_markdown(path):
         "path": str(path.with_suffix(".html")),
         "source": str(path),
     }
-    text = path.read_text()
+    text = path.read_text(encoding="utf-8")
     front_matter, markdown = text.split("---")[1:]
     page.update(yaml.safe_load(front_matter.strip()))
     page["markdown"] = markdown
@@ -277,7 +277,7 @@ def load_jupyter_notebook(path):
         "path": str(path.with_suffix(".html")),
         "source": str(path),
     }
-    notebook = nbformat.reads(path.read_text(), as_version=4)
+    notebook = nbformat.reads(path.read_text(encoding="utf-8"), as_version=4)
     image_dir = str(path.stem) + "_images"
     nbconfig = traitlets.config.Config()
     nbconfig.ExtractOutputPreprocessor.output_filename_template = os.path.join(

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ classifiers =
     Topic :: Text Processing :: Markup :: HTML
     Topic :: Text Processing :: Markup :: Markdown
     Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -32,7 +33,7 @@ project_urls =
 [options]
 zip_safe = True
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.6
 setup_requires = setuptools_scm
 install_requires =
     myst-parser>=0.15.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,6 @@ classifiers =
     Topic :: Text Processing :: Markup :: HTML
     Topic :: Text Processing :: Markup :: Markdown
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -33,7 +32,7 @@ project_urls =
 [options]
 zip_safe = True
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.7
 setup_requires = setuptools_scm
 install_requires =
     myst-parser>=0.15.0


### PR DESCRIPTION
By tests I really mean build the docs at this point. Tests will come eventually. 
Since tests were failing for Python < 3.9 and Windows, this also fixes those issues.
For Python <3.9 the `|` operator for dicts is not available. So use a dictionary unpacking solution instead. 
For Windows, it was a matter of explicitly setting the encoding to utf-8 when reading and writing text files.

Fixes #6 
