### PR TITLE
Use pypa build to create the distributions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -55,11 +55,11 @@ jobs:
           python-version: ${{ env.PYTHON }}
 
       - name: Install build requirements
-        run: python -m pip install twine setuptools_scm wheel
+        run: python -m pip install -r env/requirements-build.txt
 
       - name: Build source and wheel distributions
         run: |
-          python setup.py sdist bdist_wheel
+          make build
           echo ""
           echo "Generated files:"
           ls -lh dist/
@@ -68,7 +68,7 @@ jobs:
         run: python -m pip install `ls dist/*.whl`[jupyter]
 
       - name: List installed packages
-        run: pip freeze
+        run: python -m pip freeze
 
       - name: Build the documentation
         run: cd doc && nene
@@ -81,6 +81,7 @@ jobs:
 
       # Store the docs as a build artifact so we can deploy it later
       - name: Upload HTML documentation as an artifact
+        if: github.event_name == 'release' || github.event_name == 'push'
         uses: actions/upload-artifact@v2
         with:
           name: docs-${{ github.sha }}

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -23,10 +23,8 @@ defaults:
 ###############################################################################
 jobs:
 
-  publish:
+  build:
     runs-on: ubuntu-latest
-    # Only publish from the origin repository, not forks
-    if: github.repository_owner == 'leouieda'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -47,10 +45,10 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: Install requirements
-        run: python -m pip install -e .[dev]
+        run: python -m pip install -r env/requirements-build.txt
 
       - name: List installed packages
         run: python -m pip freeze
@@ -61,11 +59,11 @@ jobs:
           # Change setuptools-scm local_scheme to "no-local-version" so the
           # local part of the version isn't included, making the version string
           # compatible with Test PyPI.
-          sed --in-place "s/node-and-date/no-local-version/g" setup.py
+          sed --in-place "s/node-and-date/no-local-version/g" pyproject.toml
 
       - name: Build source and wheel distributions
         run: |
-          python setup.py sdist bdist_wheel
+          make build
           echo ""
           echo "Generated files:"
           ls -lh dist/
@@ -73,8 +71,39 @@ jobs:
       - name: Check the archives
         run: twine check dist/*
 
+      # Store the archives as a build artifact so we can deploy them later
+      - name: Upload archives as artifacts
+        # Only if not a pull request
+        if: success() && github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v2
+        with:
+          name: pypi-${{ github.sha }}
+          path: dist
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: build
+    # Only publish from the origin repository, not forks
+    if: github.repository_owner == 'leouieda' && github.event_name != 'pull_request'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          # The GitHub token is preserved by default but this job doesn't need
+          # to be able to push to GitHub.
+          persist-credentials: false
+
+      # Fetch the built archives from the "build" job
+      - name: Download built archives artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: pypi-${{ github.sha }}
+          path: dist
+
       - name: Publish to Test PyPI
-        if: success()
+        # Only publish to TestPyPI when a PR is merged (pushed to main)
+        if: github.event_name == 'push'
         uses: pypa/gh-action-pypi-publish@bce3b74dbf8cc32833ffba9d15f83425c1a736e0
         with:
           user: __token__
@@ -86,7 +115,7 @@ jobs:
 
       - name: Publish to PyPI
         # Only publish to PyPI when a release triggers the build
-        if: success() && github.event_name == 'release'
+        if: github.event_name == 'release'
         uses: pypa/gh-action-pypi-publish@bce3b74dbf8cc32833ffba9d15f83425c1a736e0
         with:
           user: __token__

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,5 +1,5 @@
 # Linting and style checks with GitHub Actions
-name: code-style
+name: style
 
 # Only build PRs and the main branch. Pushes to branches will only be built
 # when a PR is opened.
@@ -12,7 +12,7 @@ on:
 ###############################################################################
 jobs:
 
-  lint:
+  check:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -26,7 +26,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install requirements
-        run: python -m pip install -e .[lint]
+        run: python -m pip install -r env/requirements-style.txt
 
       - name: List installed packages
         run: python -m pip freeze

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,10 @@ on:
   release:
     types:
       - published
+  schedule:
+    # Run every Monday at 12:00 UTC
+    # * is a special character in YAML so you have to quote this string
+    - cron:  '00 12 * * 1'
 
 # Use bash by default in all jobs
 defaults:
@@ -28,18 +32,29 @@ jobs:
   #############################################################################
   # Run tests
   test:
-    name: ${{ matrix.os }} py${{ matrix.python }} ${{ matrix.dependencies }}
+    name: ${{ matrix.os }} python=${{ matrix.python }} dependencies=${{ matrix.dependencies }}
     runs-on: ${{ matrix.os }}-latest
     strategy:
       # Otherwise, the workflow would stop if a single job fails. We want to
       # run all of them to catch failures in different combinations.
       fail-fast: false
       matrix:
-        os: [ubuntu, macos, windows]
-        python: ["3.6", "3.10"]
+        os:
+          - ubuntu
+          - macos
+          - windows
+        python:
+          - "3.6"
+          - "3.10"
+        dependencies:
+          - latest
+          - oldest
     env:
+      REQUIREMENTS: env/requirements-test.txt
+      # Used to tag codecov submissions
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python }}
+      DEPENDENCIES: ${{ matrix.dependencies }}
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE
@@ -62,20 +77,45 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ env.PYTHON }}
+          python-version: ${{ matrix.python }}
 
-      - name: Install build requirements
-        run: python -m pip install twine setuptools_scm wheel
+      - name: Collect requirements - run-time
+        run: python tools/export_requirements.py > requirements-full.txt
+
+      - name: Collect requirements - convert to oldest supported
+        if: matrix.dependencies == 'oldest'
+        run: python tools/oldest_requirements.py requirements-full.txt
+
+      - name: Collect requirements - other
+        run: |
+          echo "Capturing dependencies from:"
+          for requirement in $REQUIREMENTS
+          do
+            echo "  $requirement"
+            cat $requirement >> requirements-full.txt
+          done
+
+      - name: List requirements
+        run: |
+          echo "Collected dependencies:"
+          cat requirements-full.txt
+
+      - name: Install requirements
+        run: |
+          # Install the build requirements before anything else so pip can use
+          # wheels for other packages.
+          python -m pip install --requirement env/requirements-build.txt
+          python -m pip install --requirement requirements-full.txt
 
       - name: Build source and wheel distributions
         run: |
-          python setup.py sdist bdist_wheel
+          make build
           echo ""
           echo "Generated files:"
           ls -lh dist/
 
       - name: Install the package and requirements
-        run: python -m pip install `ls dist/*.whl`[jupyter]
+        run: python -m pip install `ls dist/*.whl`
 
       - name: List installed packages
         run: python -m pip freeze

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,10 @@
+# Exclude these files from source distributions.
+# setuptools_scm includes everything else by default.
 prune .github
+prune doc
+prune env
+prune logo
+prune tools
 exclude .gitignore
+exclude Makefile
 exclude environment.yml

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 # Build, package, test, and clean
 PROJECT=nene
 
-install:
-	pip install --no-deps -e .
+.PHONY: build
+
+build:
+	python -m build .
 
 test:
 	pytest $(PYTEST_ARGS) $(PROJECT)
@@ -33,4 +35,4 @@ clean:
 	find . -name "*.pyc" -exec rm -v {} \;
 	find . -name "*.orig" -exec rm -v {} \;
 	find . -name ".coverage.*" -exec rm -v {} \;
-	rm -rvf build dist MANIFEST *.egg-info __pycache__ .coverage .cache .pytest_cache $(PROJECT)/_version.py
+	rm -rvf build dist MANIFEST .eggs *.egg-info __pycache__ .coverage .cache .pytest_cache $(PROJECT)/_version.py

--- a/env/requirements-build.txt
+++ b/env/requirements-build.txt
@@ -1,0 +1,5 @@
+# Build source and wheel distributions
+setuptools>=45
+setuptools_scm>=6.2
+wheel
+build

--- a/env/requirements-style.txt
+++ b/env/requirements-style.txt
@@ -1,0 +1,17 @@
+# Linting and formatting
+black[jupyter]
+isort
+flake8
+flake8-bugbear
+flake8-builtins
+flake8-comprehensions
+flake8-continuation
+flake8-copyright
+flake8-isort
+flake8-mutable
+flake8-print
+flake8-quotes
+flake8-simplify
+flake8-rst-docstrings
+flake8-docstrings
+pydocstyle

--- a/env/requirements-test.txt
+++ b/env/requirements-test.txt
@@ -1,0 +1,2 @@
+# Testing
+pytest

--- a/environment.yml
+++ b/environment.yml
@@ -8,4 +8,7 @@ dependencies:
   - pip
   - make
   - pip:
-    - -e .[jupyter,dev,lint]
+    - -r env/requirements-build.txt
+    - -r env/requirements-style.txt
+    - -r env/requirements-test.txt
+    - -e .[jupyter]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,13 @@
 # Specify that we use setuptools and setuptools_scm (to generate the version
 # string). Actual configuration is in setup.py and setup.cfg.
 [build-system]
-requires = ["setuptools>=30.3.0", "wheel", "setuptools_scm"]
+requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+version_scheme =  "post-release"
+local_scheme =  "node-and-date"
+write_to =  "nene/_version.py"
 
 # Make sure isort and Black are compatible
 [tool.isort]

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,6 @@ project_urls =
 zip_safe = True
 packages = find:
 python_requires = >=3.6
-setup_requires = setuptools_scm
 install_requires =
     myst-parser>=0.15.0
     jinja2>=3.0
@@ -48,27 +47,6 @@ install_requires =
 jupyter =
     nbformat
     nbconvert
-dev =
-    pytest
-    twine
-    wheel
-lint =
-    black[jupyter]
-    isort
-    flake8
-    flake8-bugbear
-    flake8-builtins
-    flake8-comprehensions
-    flake8-continuation
-    flake8-copyright
-    flake8-isort
-    flake8-mutable
-    flake8-print
-    flake8-quotes
-    flake8-simplify
-    flake8-rst-docstrings
-    flake8-docstrings
-    pydocstyle
 
 [options.entry_points]
 console_scripts =
@@ -88,3 +66,5 @@ copyright-author = Leonardo Uieda
 ignore =
     # Unknown interpreted text role "func"
     RST304
+    # Using print
+    T001

--- a/setup.py
+++ b/setup.py
@@ -2,17 +2,11 @@
 # Distributed under the terms of the MIT License.
 # SPDX-License-Identifier: MIT
 """
-Setup configuration for the Python package.
+Setup script for the Python package.
 
-Metadata and build configuration are defined in setup.cfg.
+Metadata and build configuration are defined in setup.cfg
+Uses setuptools-scm to manage version numbers using git tags.
 """
 from setuptools import setup
 
-setup(
-    use_scm_version={
-        "relative_to": __file__,
-        "version_scheme": "post-release",
-        "local_scheme": "node-and-date",
-        "write_to": "nene/_version.py",
-    }
-)
+setup()

--- a/tools/export_requirements.py
+++ b/tools/export_requirements.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2021 Leonardo Uieda.
+# Distributed under the terms of the MIT License.
+# SPDX-License-Identifier: MIT
+"""
+Export the run-time requirements from setup.cfg to a requirement.txt format.
+
+Modified from https://github.com/Unidata/MetPy
+"""
+import configparser
+
+# Read the setup.cfg
+config = configparser.ConfigParser()
+config.read("setup.cfg")
+
+print("# Run-time dependencies")
+for package in config["options"]["install_requires"].strip().split("\n"):
+    print(package.strip())
+
+print("# Extra dependencies")
+for section in config["options.extras_require"]:
+    for package in config["options.extras_require"][section].strip().split("\n"):
+        print(package.strip())

--- a/tools/oldest_requirements.py
+++ b/tools/oldest_requirements.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2021 Leonardo Uieda.
+# Distributed under the terms of the MIT License.
+# SPDX-License-Identifier: MIT
+"""
+Convert the requirements in the given file to their oldest version.
+
+Basically replaces >= with == in place.
+"""
+import sys
+
+requirements_file = sys.argv[1]
+
+
+def to_oldest(package):
+    """
+    Convert the specification to pin to the oldest version.
+
+    Takes the package specification string and replaces the >= with ==.
+    """
+    oldest = package.split(",")[0].replace(">=", "==")
+    return f"{oldest.strip()}\n"
+
+
+with open(requirements_file) as input_file:
+    requirements = [to_oldest(line) for line in input_file]
+
+with open(requirements_file, "wt") as output_file:
+    output_file.writelines(requirements)


### PR DESCRIPTION
Add the required configuration to use the `build` tool instead of
calling setup.py, which is now not really needed (but will be kept for
compatibility). Update the CI configuration to capture the dependencies
form requirements files so that we can build and test on different
versions of the packages.