### PR TITLE
Run package builds on PRs and install missing twine

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -6,8 +6,8 @@
 #
 name: pypi
 
-# Only run for pushes to the main branch and releases.
 on:
+  pull_request:
   push:
     branches:
       - main
@@ -15,7 +15,6 @@ on:
     types:
       - published
 
-# Use bash by default in all jobs
 defaults:
   run:
     shell: bash
@@ -48,7 +47,9 @@ jobs:
           python-version: "3.10"
 
       - name: Install requirements
-        run: python -m pip install -r env/requirements-build.txt
+        run: |
+          python -m pip install twine
+          python -m pip install -r env/requirements-build.txt
 
       - name: List installed packages
         run: python -m pip freeze


### PR DESCRIPTION
Forgot to install twine on CI and the build wasn't running on pull requests by mistake.