### PR TITLE
Refactor the code into an API + improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,6 @@ build/
 .eggs
 *.egg-info
 **/__pycache__
-**/_version.py
+**/_version_generated.py
 **/_build
 **/.ipynb_checkpoints

--- a/Makefile
+++ b/Makefile
@@ -35,4 +35,4 @@ clean:
 	find . -name "*.pyc" -exec rm -v {} \;
 	find . -name "*.orig" -exec rm -v {} \;
 	find . -name ".coverage.*" -exec rm -v {} \;
-	rm -rvf build dist MANIFEST .eggs *.egg-info __pycache__ .coverage .cache .pytest_cache $(PROJECT)/_version.py
+	rm -rvf build dist MANIFEST .eggs *.egg-info __pycache__ .coverage .cache .pytest_cache $(PROJECT)/_version_generated.py

--- a/doc/build_and_serve.py
+++ b/doc/build_and_serve.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2021 Leonardo Uieda.
+# Distributed under the terms of the MIT License.
+# SPDX-License-Identifier: MIT
+"""Trying out the API to build the site with a script instead of the CLI."""
+import nene
+
+site, source_files, config = nene.build("config.yml")
+nene.export(site, source_files["copy"], output_dir=config["output_dir"])
+nene.serve(config, source_files)

--- a/nene/__init__.py
+++ b/nene/__init__.py
@@ -2,13 +2,7 @@
 # Distributed under the terms of the MIT License.
 # SPDX-License-Identifier: MIT
 """
-Nēnē: A no-nonsense static site generator.
-
-See:
-
-* nene.cli: the command-line application.
-* nene.core: functions for building, parsing, converting, etc.
+Nēnē: A no-frills static site generator.
 """
-from . import _version
-
-__version__ = f"v{_version.version}"
+from ._api import build, export, serve
+from ._version import __version__

--- a/nene/_api.py
+++ b/nene/_api.py
@@ -1,0 +1,271 @@
+# Copyright (c) 2021 Leonardo Uieda.
+# Distributed under the terms of the MIT License.
+# SPDX-License-Identifier: MIT
+"""Public functions used for building and serving the website."""
+import logging
+import shutil
+from pathlib import Path
+
+import livereload
+
+from .crawling import crawl
+from .parsing import load_config, load_data, load_jupyter_notebook, load_markdown
+from .printing import make_console, print_dict, print_file_stats
+from .rendering import make_jinja_env, render_html, render_markdown
+from .utils import capture_build_info
+
+
+def build(config_file, console=None, style=""):
+    """
+    Build the website from the sources.
+
+    Reads in configuration and data sources. Renders templates and generates
+    the outputs (generally HTML) in memory.
+
+    Parameters
+    ----------
+    config_file : str
+        Path to the configuration file.
+    console : rich.console.Console
+        Console used to print status messaged. If None, no messages are
+        printed.
+    style : str
+        Style string used to format console status messages.
+
+    Returns
+    -------
+    site : dict
+        The generated website as a dictionary of pages. Each page has a unique
+        ID (usually the relative file path without extension) and is a
+        dictionary. The rendered HTML of the page is in ``page["html"]``.
+    source_files : dict
+        Dictionary with lists of source files by file type.
+    config : dict
+        Parameters read from the main configuration file.
+    """
+    if console is None:
+        console, style = make_console(verbose=False)
+
+    console.print(
+        ":package: Captured information about the build environment:", style=style
+    )
+    build = capture_build_info()
+    print_dict(build, console)
+
+    console.print(f":package: Configuration loaded from '{config_file}':", style=style)
+    config = load_config(config_file)
+    print_dict(config, console)
+
+    console.print(":open_file_folder: Scanned source directory:", style=style)
+    source_files = crawl(
+        root=Path("."), ignore=config["ignore"], copy_extra=config["copy"]
+    )
+    print_file_stats(source_files, console)
+
+    site = {}
+
+    console.print(":open_book: Reading Markdown files:", style=style)
+    if source_files["markdown"]:
+        for path in source_files["markdown"]:
+            console.print(f"   {str(path)}")
+            page = load_markdown(path)
+            site[page["id"]] = page
+    else:
+        console.print("   None found.")
+
+    console.print(
+        ":open_book: Reading Jupyter Notebook files as Markdown:", style=style
+    )
+    if source_files["ipynb"]:
+        for path in source_files["ipynb"]:
+            console.print(f"   {str(path)}")
+            page = load_jupyter_notebook(path)
+            site[page["id"]] = page
+    else:
+        console.print("   None found.")
+
+    console.print(":open_book: Reading JSON and YAML data files:", style=style)
+    data = {}
+    data_files = source_files["json"] + source_files["yaml"]
+    if data_files:
+        # Organizing data by parent folder makes it easier to apply it later
+        for path in sorted(data_files):
+            console.print(f"   {str(path)}")
+            datum = load_data(path)
+            if datum["parent"] not in data:
+                data[datum["parent"]] = []
+            data[datum["parent"]].append(datum)
+    else:
+        console.print("   None found.")
+
+    console.print(":truck: Propagating data through the website:", style=style)
+    if data:
+        for page in site.values():
+            if page["parent"] in data:
+                console.print(f"   {page['source']}:")
+                for datum in data[page["parent"]]:
+                    console.print(f"     ↳ {datum['source']}")
+                    # Merge the two data dictionaries with 'page' taking precedence
+                    page.update({**datum["content"], **page})
+    else:
+        console.print("   None found.")
+
+    jinja_env = make_jinja_env(config["templates_dir"])
+
+    console.print(":art: Rendering templates in Markdown content:", style=style)
+    for page in site.values():
+        console.print(f"   {page['source']}")
+        page["markdown"] = render_markdown(page, config, site, build, jinja_env)
+
+    console.print(":art: Rendering templates for HTML output:", style=style)
+    for page in site.values():
+        console.print(f"   {page['path']} ← {page['template']}")
+        page["html"] = render_html(page, config, site, build, jinja_env)
+
+    return site, source_files, config
+
+
+def export(site, files_to_copy, output_dir, console=None, style=""):
+    """
+    Write the output (HTML) and other website files to disk.
+
+    To be used after running ``build``.
+
+    Parameters
+    ----------
+    site : dict
+        The generated website as a dictionary of pages.
+    files_to_copy : list
+        List of paths to files that need to be copied to the output folder.
+    output_dir : str or pathlib.Path
+        Path of the output folder.
+    console : rich.console.Console
+        Console used to print status messaged. If None, no messages are
+        printed.
+    style : str
+        Style string used to format console status messages.
+    """
+    if console is None:
+        console, style = make_console(verbose=False)
+
+    output_dir = Path(output_dir)
+    output_dir.mkdir(exist_ok=True)
+
+    console.print(
+        ":deciduous_tree: Copying source directory tree and extra files to "
+        f"'{str(output_dir)}':",
+        style=style,
+    )
+    for path in files_to_copy:
+        console.print(f"   {str(path)}")
+        destination = output_dir / path
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(path, destination)
+
+    console.print(
+        f":writing_hand:  Writing output files to '{str(output_dir)}':", style=style
+    )
+    for page in site.values():
+        destination = output_dir / Path(page["path"])
+        console.print(f"   {str(destination)} ⇒  id: {page['id']}")
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_text(page["html"], encoding="utf-8")
+
+    console.print(":bar_chart: Writing Jupyter Notebook image files:", style=style)
+    pages_with_images = [
+        page
+        for page in site.values()
+        if "images" in page and page["images"] is not None
+    ]
+    if pages_with_images:
+        for page in pages_with_images:
+            console.print(f"   {page['source']}")
+            for image_path, image in page["images"].items():
+                path = output_dir / Path(page["parent"]) / Path(image_path)
+                console.print(f"     ↳ {str(path)}")
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_bytes(image)
+    else:
+        console.print("   None found.")
+
+    console.print(
+        f":gift: Your built website is in '{str(output_dir)}'. Enjoy!",
+        style=style,
+    )
+
+
+def serve(config, source_files, port=None, console=None, style=""):
+    """
+    Serve the output folder with livereload and watch the sources for changes.
+
+    When any of the source files are changed, the website is rebuilt
+    automatically.
+
+    Parameters
+    ----------
+    config : dict
+        Parameters read from the main configuration file.
+    source_files : dict
+        Dictionary with lists of source files by file type.
+    port : int
+        The port used by the server. If None, will first try port 5500 and
+        increase by 1 if the port is already busy (maximum of 10 times).
+    console : rich.console.Console
+        Console used to print status messaged. If None, no messages are
+        printed.
+    style : str
+        Style string used to format console status messages.
+    """
+    # Note: Can't really quite the livereload server since it sets the logging
+    # level and handler when "serve" is called. So we can't set it before
+    # anything happens. See livereload/server.py line 331 (as of 2022-04-08).
+    livereload_logger = logging.getLogger("livereload")
+    if console is None:
+        console, style = make_console(verbose=False)
+
+    config_file = config["config_file"]
+    watch = [config_file, config["templates_dir"]]
+    for category in source_files:
+        watch.extend(source_files[category])
+    # Make all paths into strings to avoid "JSON serialization errors" coming
+    # from livereload
+    watch = sorted([str(fname) for fname in watch])
+
+    def rebuild():
+        """Rebuild the website."""
+        site, source_files, config = build(config_file)
+        export(site, source_files["copy"], config["output_dir"])
+
+    console.print(":eyes: Watching these source files for changes:", style=style)
+    server = livereload.Server()
+    for fname in watch:
+        console.print(f"   {fname}")
+        server.watch(fname, rebuild)
+
+    if port is None:
+        max_attempts = 10
+        port = 5500
+    else:
+        max_attempts = 1
+    for attempt in range(max_attempts):
+        console.print(":ledger: Server log messages:", style=style)
+        try:
+            server.serve(
+                root=str(config["output_dir"]),
+                host="localhost",
+                port=port,
+                open_url_delay=1,
+            )
+            break
+        except OSError:
+            if attempt == max_attempts + 1:
+                raise
+            console.print(
+                "   Failed to start server because "
+                f"port {port} is already in use. "
+                "Trying another port."
+            )
+            port += 1
+            # Clear the logger to avoid having livereload duplicate the
+            # handlers causing multiple prints of the same log messages.
+            livereload_logger.handlers.clear()

--- a/nene/_version.py
+++ b/nene/_version.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2021 Leonardo Uieda.
+# Distributed under the terms of the MIT License.
+# SPDX-License-Identifier: MIT
+"""Version string coming from setuptools_scm."""
+from . import _version_generated
+
+# Create this in a separate module to avoid circular imports when placed in
+# nene/__init__.py
+__version__ = f"v{_version_generated.version}"

--- a/nene/cli.py
+++ b/nene/cli.py
@@ -1,24 +1,13 @@
 # Copyright (c) 2021 Leonardo Uieda.
 # Distributed under the terms of the MIT License.
 # SPDX-License-Identifier: MIT
-"""
-Defines the command line interface.
-
-Uses click to define a CLI around the ``main`` function.
-"""
-import logging
-import shutil
+"""The Click command line interface ("main" function)."""
 import sys
-from pathlib import Path
 
 import click
-import livereload
 
-from .crawling import crawl
-from .parsing import load_config, load_data, load_jupyter_notebook, load_markdown
-from .printing import make_console, print_dict, print_file_stats
-from .rendering import make_jinja_env, render_html, render_markdown
-from .utils import capture_build_info
+from . import _api
+from .printing import make_console
 
 CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
 DEFAULT_CONFIG = "config.yml"
@@ -56,25 +45,31 @@ def main(config, serve, verbose):
     found in the current directory.
     """
     config_file = config
-    console = make_console(verbose)
-    style = "bold blue"
+    console, style = make_console(verbose)
+    style_rule = "green"
     console.rule(
-        ":palm_tree: Lay back and relax while Nēnē builds your website :palm_tree:",
+        f":palm_tree: [{style_rule}]Lay back and relax while Nēnē builds "
+        "your website[/] :palm_tree:",
         style=style,
     )
+    # Main website building section
     try:
-        output, tree, config = build(config_file, console, style)
+        with console.status(f"[{style}]Working...[/{style}]"):
+            site, source_files, config = _api.build(config_file, console, style)
+            _api.export(
+                site, source_files["copy"], config["output_dir"], console, style
+            )
+    # Handle exceptions nicely when they occur
     except Exception:
-        console_error = make_console(verbose=True)
-        style = "bold red"
+        console_error, style_error = make_console(verbose=True, style="bold red")
         console.print()
-        console.rule(":fire: Error messages start here :fire:", style=style)
+        console.rule(":fire: Error messages start here :fire:", style=style_error)
         console.print_exception(suppress=[click])
-        console.rule(":fire: Error messages above :fire:", style=style)
+        console.rule(":fire: Error messages above :fire:", style=style_error)
         console.print()
         console_error.print(
             ":pensive: Oh no! Something went wrong while building your website.",
-            style=style,
+            style=style_error,
         )
         if not verbose:
             console_error.print(
@@ -96,199 +91,18 @@ def main(config, serve, verbose):
         console.print()
         sys.exit(1)
     else:
-        console.rule(":rocket: [bold green]Done![/] :tada:", style=style)
-        console.print()
-        console.print(
-            f":gift: Your built website is in '{str(output)}'. Enjoy!",
-            style="bold green",
-        )
-
+        if not serve:
+            console.rule(f":tada: [{style_rule}]Done![/] :tada:", style=style)
+    # Start the livereload server is requested
     if serve:
-        console.print()
         console.rule(
-            f":eyes: Serving files in '{config['output_dir']}' and "
-            f"watching for changes in the sources",
+            f":robot: [{style_rule}]Starting development server[/] :robot:",
             style=style,
         )
-        serve_and_watch(
-            output,
-            config_file,
-            watch=tree,
-            extra=[config_file, config["templates_dir"]],
-            quiet=not verbose,
+        _api.serve(
+            config,
+            source_files,
+            console=console,
+            style=style,
         )
     sys.exit(0)
-
-
-def build(config_file, console, style):
-    """
-    Build the website HTML.
-
-    Main function used to build the website. Reads in data from files,
-    converts, renders, etc.
-
-    Parameters
-    ----------
-    config_file : str
-        Path to the configuration file.
-    console : rich.console.Console
-        The rich Console used to print log messages.
-    style : str
-        Formatting style used for the main status messages.
-
-    Returns
-    -------
-    output : pathlib.Path
-        Path of the output folder.
-    tree : dict
-        Dictionary with lists of source files by file type.
-    config : dict
-        Parameters read from the main configuration file.
-    """
-    with console.status(f"[{style}]Working...[/{style}]"):
-        console.print(
-            ":package: Captured information about the build environment:", style=style
-        )
-        build = capture_build_info()
-        print_dict(build, console)
-
-        console.print(
-            f":package: Configuration loaded from '{config_file}':", style=style
-        )
-        config = load_config(config_file)
-        print_dict(config, console)
-
-        console.print(":open_file_folder: Scanned source directory:", style=style)
-        tree = crawl(root=Path("."), ignore=config["ignore"], copy_extra=config["copy"])
-        print_file_stats(tree, console)
-
-        output = Path(config["output_dir"])
-        output.mkdir(exist_ok=True)
-
-        jinja_env = make_jinja_env(config["templates_dir"])
-
-        site = {}
-        data = {}
-
-        console.print(":open_book: Reading Markdown files:", style=style)
-        if tree["markdown"]:
-            for path in tree["markdown"]:
-                console.print(f"   {str(path)}")
-                page = load_markdown(path)
-                site[page["id"]] = page
-        else:
-            console.print("   There weren't any :disappointed:")
-
-        console.print(
-            ":open_book: Reading Jupyter Notebook files as Markdown:", style=style
-        )
-        if tree["ipynb"]:
-            for path in tree["ipynb"]:
-                console.print(f"   {str(path)}")
-                page = load_jupyter_notebook(path)
-                site[page["id"]] = page
-        else:
-            console.print("   There weren't any :disappointed:")
-
-        console.print(":open_book: Reading JSON data files:", style=style)
-        if tree["json"] + tree["yaml"]:
-            # Organizing data by parent folder makes it easier to apply it later
-            for path in sorted(tree["json"] + tree["yaml"]):
-                console.print(f"   {str(path)}")
-                datum = load_data(path)
-                if datum["parent"] not in data:
-                    data[datum["parent"]] = []
-                data[datum["parent"]].append(datum)
-        else:
-            console.print("   There weren't any :disappointed:")
-
-        console.print(":truck: Propagating data through the website:", style=style)
-        if data:
-            for page in site.values():
-                if page["parent"] in data:
-                    console.print(f"   {page['source']}:")
-                    for datum in data[page["parent"]]:
-                        console.print(f"     ↳ {datum['source']}")
-                        # Merge the two data dictionaries with 'page' taking precedence
-                        page.update({**datum["content"], **page})
-        else:
-            console.print("   There wasn't any :disappointed:")
-
-        console.print(":art: Rendering templates in Markdown content:", style=style)
-        for page in site.values():
-            console.print(f"   {page['id']}")
-            page["markdown"] = render_markdown(page, config, site, build, jinja_env)
-
-        console.print(":art: Rendering templates for HTML output:", style=style)
-        rendered_html = {}
-        for page in site.values():
-            console.print(f"   {page['id']} ← {page['template']}")
-            rendered_html[page["id"]] = render_html(
-                page, config, site, build, jinja_env
-            )
-
-        console.print(
-            ":deciduous_tree: Copying source directory tree and extra files to "
-            f"'{str(output)}':",
-            style=style,
-        )
-        for path in tree["copy"]:
-            console.print(f"   {str(path)}")
-            destination = output / path
-            destination.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copyfile(path, destination)
-
-        console.print(
-            f":writing_hand:  Writing HTML files to '{str(output)}':", style=style
-        )
-        for identifier in rendered_html:
-            page = site[identifier]
-            destination = output / Path(page["path"])
-            console.print(f"   {str(destination)} ⇒  id: {page['id']}")
-            destination.parent.mkdir(parents=True, exist_ok=True)
-            destination.write_text(rendered_html[identifier], encoding="utf-8")
-
-        console.print(":bar_chart: Writing Jupyter Notebook image files:", style=style)
-        if tree["ipynb"]:
-            for page in site.values():
-                if "images" in page:
-                    console.print(f"   {page['source']}")
-                    for image_path, image in page["images"].items():
-                        path = output / Path(page["parent"]) / Path(image_path)
-                        console.print(f"     ↳ {str(path)}")
-                        path.parent.mkdir(parents=True, exist_ok=True)
-                        path.write_bytes(image)
-        else:
-            console.print("   There weren't any :disappointed:")
-    return output, tree, config
-
-
-def serve_and_watch(path, config_file, watch, extra, quiet):
-    """
-    Serve the output folder with livereload and watch the tree and extra files.
-
-    Parameters
-    ----------
-    path : str or :class:`pathlib.Path`
-        The path that will be served.
-    config_file : str or :class:`pathlib.Path`
-        The configuration file used.
-    watch : dict
-        Dictionary with lists of source files that will be watched for changes.
-        Usually the output of :func:`nene.core.crawl`.
-    extra : list
-        List of extra files to watch.
-    quiet: bool
-        If True, will set logging output from livereload only at "ERROR" level.
-
-    """
-    if quiet:
-        logger = logging.getLogger("livereload")
-        logger.setLevel("ERROR")
-    server = livereload.Server()
-    files = list(extra)
-    for category in watch:
-        files.extend(watch[category])
-    for filename in files:
-        server.watch(filename, f"nene --config={config_file} --quiet")
-    server.serve(root=path, host="localhost", open_url_delay=1)

--- a/nene/parsing.py
+++ b/nene/parsing.py
@@ -62,6 +62,7 @@ def load_config(fname):
         "output_dir": "_build",
         "templates_dir": "_templates",
         "copy": [],
+        "config_file": str(fname),
     }
     config.update(_read_data_file(fname))
     config["ignore"].append(fname)

--- a/nene/printing.py
+++ b/nene/printing.py
@@ -6,7 +6,7 @@
 import rich.console
 
 
-def make_console(verbose):
+def make_console(verbose, style="bold blue"):
     """
     Start up the :class:`rich.console.Console` instance we'll use.
 
@@ -15,7 +15,8 @@ def make_console(verbose):
     verbose : bool
         Whether or not to print status messages to stderr.
     """
-    return rich.console.Console(stderr=True, quiet=not verbose, highlight=False)
+    console = rich.console.Console(stderr=True, quiet=not verbose, highlight=False)
+    return console, style
 
 
 def print_dict(dictionary, console):

--- a/nene/utils.py
+++ b/nene/utils.py
@@ -6,7 +6,7 @@ import contextlib
 import datetime
 import subprocess
 
-from . import __version__ as nene_version
+from ._version import __version__ as nene_version
 
 
 def generate_identifier(path):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools_scm]
 version_scheme =  "post-release"
 local_scheme =  "node-and-date"
-write_to =  "nene/_version.py"
+write_to =  "nene/_version_generated.py"
 
 # Make sure isort and Black are compatible
 [tool.isort]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = nene
 fullname = Nēnē
-description = "A no-frills static site generator"
+description = A no-frills static site generator
 long_description = file: README.md
 long_description_content_type = text/markdown
 author = Leonardo Uieda
@@ -57,7 +57,7 @@ max-line-length = 88
 show-source = True
 application-import-names = nene
 docstring-convention = numpy
-exclude = doc .eggs *.egg-info nene/_version.py build
+exclude = doc .eggs *.egg-info nene/_version_generated.py nene/__init__.py build
 select = A B C D E F G H I J K L M N O P Q R S T U V W X Y Z B902
 inline-quotes = double
 multiline-quotes = double


### PR DESCRIPTION
Make an actual API that can be used to build a website through a script.
The API consists of 3 functions: build (generates the full website in
memory), export (saves things to disk), and serve (starts the livereload
server). This would allow users to process the output of build (the
whole site as dictionary, config, and lists of source files) before
exporting the website. See doc/build_and_serve.py for an example.
Other improvements:
Log messages got a clean up.
Fix livereload error about JSON serialization.
Allow livereload to try different ports before giving up.