### PR TITLE
Split the build process from the rendering

### DIFF
--- a/doc/build.py
+++ b/doc/build.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2021 Leonardo Uieda.
+# Distributed under the terms of the MIT License.
+# SPDX-License-Identifier: MIT
+"""Trying out the API to build the site with a script instead of the CLI."""
+import sys
+
+import nene
+
+if __name__ == "__main__":
+    # Create a Rich Console for printing status updates. To omit the messages,
+    # don't pass the console and style to the functions below.
+    console, style = nene.printing.make_console(verbose=True)
+    # So we know that we're using this script and not the "nene" app.
+    console.rule()
+    console.print(":snake: Building from the 'build.py' Python script.", style=style)
+    console.rule()
+
+    # Generate the website structure based on the YAML configuration file.
+    site, source_files, config, build = nene.build(
+        "config.yml", console=console, style=style
+    )
+    # Render the HTML for the website.
+    nene.render(site, config, build, console=console, style=style)
+    # Export the rendered website to files (including everything that needs to
+    # be copied over).
+    nene.export(
+        site, source_files["copy"], config["output_dir"], console=console, style=style
+    )
+    # If the script is called with the "-s" command line option, serve the
+    # website and open it in a browser.
+    if "-s" in sys.argv:
+        nene.serve(config, source_files, console=console, style=style)

--- a/doc/build_and_serve.py
+++ b/doc/build_and_serve.py
@@ -1,9 +1,0 @@
-# Copyright (c) 2021 Leonardo Uieda.
-# Distributed under the terms of the MIT License.
-# SPDX-License-Identifier: MIT
-"""Trying out the API to build the site with a script instead of the CLI."""
-import nene
-
-site, source_files, config = nene.build("config.yml")
-nene.export(site, source_files["copy"], output_dir=config["output_dir"])
-nene.serve(config, source_files)

--- a/doc/config.yml
+++ b/doc/config.yml
@@ -18,3 +18,4 @@ menu:
 ignore:
   - README.md
   - config-alternative.json
+  - "*.py"

--- a/nene/__init__.py
+++ b/nene/__init__.py
@@ -4,5 +4,5 @@
 """
 Nēnē: A no-frills static site generator.
 """
-from ._api import build, export, serve
+from ._api import build, export, render, serve
 from ._version import __version__

--- a/nene/cli.py
+++ b/nene/cli.py
@@ -55,7 +55,8 @@ def main(config, serve, verbose):
     # Main website building section
     try:
         with console.status(f"[{style}]Working...[/{style}]"):
-            site, source_files, config = _api.build(config_file, console, style)
+            site, source_files, config, build = _api.build(config_file, console, style)
+            _api.render(site, config, build, console, style)
             _api.export(
                 site, source_files["copy"], config["output_dir"], console, style
             )


### PR DESCRIPTION
The build function now returns the website structure before rendering.
This allows us to insert content into `site`, `config`, and `build`
dictionaries before passing them on to the rendering function which
calls Jinja. Modernize the example `build.py` script to use the new
format.