### PR TITLE
Load the Markdown template from a string instead

### DIFF
--- a/nene/rendering.py
+++ b/nene/rendering.py
@@ -70,9 +70,7 @@ def render_markdown(page, config, site, build, jinja_env):
     markdown : str
         The rendered Markdown content for the page.
     """
-    # Jinja doesn't allow \ as paths even on Windows
-    # https://github.com/pallets/jinja/issues/711
-    template = jinja_env.get_template(str(page["source"]).replace("\\", "/"))
+    template = jinja_env.from_string(page["markdown"])
     markdown = template.render(page=page, config=config, site=site, build=build)
     return markdown
 


### PR DESCRIPTION
Loading from the file, as we did before, will load a markdown content
with the yaml header still there. Use `from_string` instead to load the
template from the parsed `page["markdown"]` content. Avoid repeated IO
and the Windows path replacement hack.