### PR TITLE
Use current year for copyright in the docs

### DIFF
--- a/doc/_templates/base.html
+++ b/doc/_templates/base.html
@@ -115,7 +115,7 @@
         Built with <a href="https://nene.leouieda.com">Nēnē</a> {{ build.nene_version }}
       </p>
       <p>
-        Copyright &copy; 2021 {{ config.author }}
+        Copyright &copy; {{ build.today.year }} {{ config.author }}
       </p>
     </div>
   </footer>


### PR DESCRIPTION
Instead of the fixed 2021, use the `build.today` date.