### PR TITLE
Use markdown-it-py to render Markdown content

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python==3.9
+  - python==3.10
   - pip
   - make
   - pip:

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ license_file = LICENSE.txt
 platform = any
 keywords = html, markdown
 classifiers =
-    Development Status :: 3 - Alpha
+    Development Status :: 4 - Beta
     Intended Audience :: Developers
     License :: OSI Approved :: MIT License
     Natural Language :: English
@@ -36,7 +36,8 @@ zip_safe = True
 packages = find:
 python_requires = >=3.6
 install_requires =
-    myst-parser>=0.15.0
+    markdown-it-py>=2.0
+    mdit-py-plugins>=0.3
     jinja2>=3.0
     pyyaml>=5.4
     livereload>=2.6


### PR DESCRIPTION
Replace the MyST parser, which actually uses markdown-it-py. MyST is
meant to be used with sphinx and didn't really offer that much in the
way of customizing the Markdown rendering process. With markdown-it-py
we can use some of their plugins and even write some of our own to
support things like syntax highlighting for code blocks (with language
specification, like in GitHub flavored markdown). For now, just replace
the rendering and add a few plugins (typographic substitutions,
footnotes, tables, and anchors for headings.