### PR TITLE
Parse notebook content without nbconvert

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,6 @@ install_requires =
 [options.extras_require]
 jupyter =
     nbformat
-    nbconvert
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
Use nbformat directly to convert the notebook to Markdown without going
through nbconvert. It's what myst-nb does and probably the best way to
capture rich display from the notebook. Not finished yet since some
things aren't parsing properly. Particularly the html and css styles are
getting turned into code blocks by markdown-it-py because of their
indentation.