### PR TITLE
Support BibTeX files as data in addition to yaml and json

### DIFF
--- a/nene/_api.py
+++ b/nene/_api.py
@@ -91,7 +91,7 @@ def build(config_file, console=None, style=""):
     console.print(
         ":open_book: Reading data files and propagating to pages:", style=style
     )
-    data_files = source_files["json"] + source_files["yaml"]
+    data_files = source_files["json"] + source_files["yaml"] + source_files["bibtex"]
     if data_files:
         for path in sorted(data_files):
             console.print(f"   {str(path)}")

--- a/nene/crawling.py
+++ b/nene/crawling.py
@@ -58,6 +58,7 @@ def crawl(root, ignore, copy_extra):
         ".yml": "yaml",
         ".yaml": "yaml",
         ".ipynb": "ipynb",
+        ".bib": "bibtex",
     }
     tree = {
         "copy": [Path(path) for path in copy_extra],
@@ -65,6 +66,7 @@ def crawl(root, ignore, copy_extra):
         "ipynb": [],
         "json": [],
         "yaml": [],
+        "bibtex": [],
     }
     expanded_ignore = []
     for path in ignore:

--- a/nene/parsing.py
+++ b/nene/parsing.py
@@ -17,7 +17,7 @@ except ImportError:
     nbformat = None
 
 # For bibtex support
-try: 
+try:
     import bibtexparser
     from bibtexparser.bparser import BibTexParser
     from bibtexparser.customization import convert_to_unicode

--- a/nene/parsing.py
+++ b/nene/parsing.py
@@ -4,6 +4,7 @@
 """Load data from source files."""
 import json
 from pathlib import Path
+
 import yaml
 
 # For Jupyter notebook support


### PR DESCRIPTION
Hi @leouieda,

in this PR, I added basic support for bibtex files (via [`bibtexparser`](https://bibtexparser.readthedocs.io/)) to populate pages with data similiar to the already existing support for json and yaml. 

Two issues that I would like to discuss with you:

1. The *yaml* and *json* data directly populate the "main namespace" of the page. I chose to add the *bibtex* data one level below, so that it can be accessed separately. I also thought one might have multiple bibfiles, e.g. one with journal articles and one with conference contributions. So if you have `articles.bib` and `conferences.bib`, the data is currently in `page["bibtex_articles"]` and `page["bibtex_conferences"]`. Let me know if you can live with that or have a better idea.
2. I tried to make it optional, similar to the handling of jupyter notebooks. Since `bibtexparser` is pretty lightweight and `nene` will probably be used in academia a lot, one could also add it to the dependencies. But maybe this is in conflict with *no-frills*. You should decide.

**Usage example**:

You could add any `.bib` file somewhere in the file tree. If I choose [this one for example](https://github.com/florian-wagner/website/blob/master/content/articles.bib), I can render the articles like this:

``` html
---
template: base.html
title: Publications
---

<ul>
{%- for item in page["bibtex_articles"]|sort(attribute="year", reverse=True) %}
  <li>
    {{ item.author }} ({{ item.year }}): {{ item.title }}, <em>{{ item.journal }}</em>, <a href="https://doi.org/{{ item.doi }}">doi:{{ item.doi }}</a>.
  </li>
{%- endfor %}
</ul>
```

Let me know what you think and feel free to edit and criticize the code of course.

Best wishes
Florian


