### PR TITLE
Provide option for cleaner/prettier links by removing .html suffix

### DIFF
--- a/nene/_api.py
+++ b/nene/_api.py
@@ -116,9 +116,10 @@ def build(config_file, console=None, style=""):
     for page in site.values():
         if "save_as" in page:
             destination = Path(page["source"]).with_name(page["save_as"])
-        elif "link_style" in config and not page["source"].endswith("index.md"):
-            if config["link_style"] == "pretty":
-                destination = Path(page["id"]) / "index.html"
+        elif "link_style" in config and not page["source"].endswith("index.md") \
+            and not page["source"] == "404.md":
+                if config["link_style"] == "pretty":
+                    destination = Path(page["id"]) / "index.html"
         else:
             destination = Path(page["source"]).with_suffix(".html")
         page["path"] = str(destination)

--- a/nene/_api.py
+++ b/nene/_api.py
@@ -116,8 +116,8 @@ def build(config_file, console=None, style=""):
     for page in site.values():
         if "save_as" in page:
             destination = Path(page["source"]).with_name(page["save_as"])
-        elif "link_style" in config:
-            if config["link_style"] == "pretty" and not page["source"].endswith("index.md"):
+        elif "link_style" in config and not page["source"].endswith("index.md"):
+            if config["link_style"] == "pretty":
                 destination = Path(page["id"]) / "index.html"
         else:
             destination = Path(page["source"]).with_suffix(".html")

--- a/nene/_api.py
+++ b/nene/_api.py
@@ -112,14 +112,18 @@ def build(config_file, console=None, style=""):
     else:
         console.print("   None found.")
 
+    def pretty_links(source, config):
+        """Whether or not this page link should be prettyfied."""
+        activated = "pretty_links" in config and config["pretty_links"]
+        valid_page = not source.endswith("index.md") and source != "404.md"
+        return activated and valid_page
+
     console.print(":dart: Determining destination path for pages:", style=style)
     for page in site.values():
         if "save_as" in page:
             destination = Path(page["source"]).with_name(page["save_as"])
-        elif "link_style" in config and not page["source"].endswith("index.md") \
-            and not page["source"] == "404.md":
-                if config["link_style"] == "pretty":
-                    destination = Path(page["id"]) / "index.html"
+        elif pretty_links(page["source"], config):
+            destination = Path(page["id"]) / "index.html"
         else:
             destination = Path(page["source"]).with_suffix(".html")
         page["path"] = str(destination)
@@ -252,7 +256,7 @@ def export(site, files_to_copy, output_dir, console=None, style=""):
         for page in pages_with_images:
             console.print(f"   {page['source']}")
             for image_path, image in page["images"].items():
-                path = output_dir / Path(page["parent"]) / Path(image_path)
+                path = output_dir / Path(page["path"]).parent / Path(image_path)
                 console.print(f"     ↳ {str(path)}")
                 path.parent.mkdir(parents=True, exist_ok=True)
                 path.write_bytes(image)

--- a/nene/_api.py
+++ b/nene/_api.py
@@ -116,6 +116,8 @@ def build(config_file, console=None, style=""):
     for page in site.values():
         if "save_as" in page:
             destination = Path(page["source"]).with_name(page["save_as"])
+        elif config["link_style"] == "pretty" and not page["source"].endswith("index.md"):
+            destination = Path(page["id"]) / "index.html"
         else:
             destination = Path(page["source"]).with_suffix(".html")
         page["path"] = str(destination)

--- a/nene/_api.py
+++ b/nene/_api.py
@@ -116,8 +116,9 @@ def build(config_file, console=None, style=""):
     for page in site.values():
         if "save_as" in page:
             destination = Path(page["source"]).with_name(page["save_as"])
-        elif config["link_style"] == "pretty" and not page["source"].endswith("index.md"):
-            destination = Path(page["id"]) / "index.html"
+        elif "link_style" in config:
+            if config["link_style"] == "pretty" and not page["source"].endswith("index.md"):
+                destination = Path(page["id"]) / "index.html"
         else:
             destination = Path(page["source"]).with_suffix(".html")
         page["path"] = str(destination)


### PR DESCRIPTION
Hi @leouieda,

this relatively small change allows to remove all `.html` suffixes from `{page}.html` by creating `{page}/index.html`. It can be activated by putting `link_style: pretty` in the config. Jekyll, Pelican and others have this feature and for me this provides a lot of benefits when not all the source files are named `index.md`.

This is a starting point and probably goes south when `{page}` exists as a folder alongside `{page}.md`. And it may also cause problems when using relative links, which I have not done yet, but I saw that you made this possible recently by a new jinja filter.

Let me know what you think.
Florian