### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
           - macos
           - windows
         python:
-          - "3.6"
+          - "3.7"
           - "3.10"
         dependencies:
           - latest

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,6 @@ classifiers =
     Topic :: Text Processing :: Markup :: HTML
     Topic :: Text Processing :: Markup :: Markdown
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -34,7 +33,7 @@ project_urls =
 [options]
 zip_safe = True
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires =
     markdown-it-py>=2.0
     mdit-py-plugins>=0.3


### PR DESCRIPTION
It's been discontinued a while ago so we are past due dropping this.