### PR TITLE
Add support for syntax highlighting with pygments

### DIFF
--- a/doc/_templates/base.html
+++ b/doc/_templates/base.html
@@ -52,6 +52,8 @@
   <link rel="stylesheet" href="{{ "css/bootstrap-5.1/bootstrap.min.css"|relative_to(page.path) }}">
   <!-- FontAwsome icons -->
   <link rel="stylesheet" href="{{ "css/fontawesome/css/all.css"|relative_to(page.path) }}">
+  <!-- Syntax highlighting -->
+  <link rel="stylesheet" href="{{ "css/pygments.css"|relative_to(page.path) }}">
   <!-- Main CSS stylesheet -->
   <link rel="stylesheet" href="{{ "css/style.css"|relative_to(page.path) }}">
 

--- a/doc/css/pygments.css
+++ b/doc/css/pygments.css
@@ -1,0 +1,75 @@
+pre { line-height: 125%; }
+td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+.highlight .hll { background-color: #ffffcc }
+.highlight { background: #f8f8f8; }
+.highlight .c { color: #3D7B7B; font-style: italic } /* Comment */
+.highlight .err { border: 1px solid #F00 } /* Error */
+.highlight .k { color: #008000; font-weight: bold } /* Keyword */
+.highlight .o { color: #666 } /* Operator */
+.highlight .ch { color: #3D7B7B; font-style: italic } /* Comment.Hashbang */
+.highlight .cm { color: #3D7B7B; font-style: italic } /* Comment.Multiline */
+.highlight .cp { color: #9C6500 } /* Comment.Preproc */
+.highlight .cpf { color: #3D7B7B; font-style: italic } /* Comment.PreprocFile */
+.highlight .c1 { color: #3D7B7B; font-style: italic } /* Comment.Single */
+.highlight .cs { color: #3D7B7B; font-style: italic } /* Comment.Special */
+.highlight .gd { color: #A00000 } /* Generic.Deleted */
+.highlight .ge { font-style: italic } /* Generic.Emph */
+.highlight .ges { font-weight: bold; font-style: italic } /* Generic.EmphStrong */
+.highlight .gr { color: #E40000 } /* Generic.Error */
+.highlight .gh { color: #000080; font-weight: bold } /* Generic.Heading */
+.highlight .gi { color: #008400 } /* Generic.Inserted */
+.highlight .go { color: #717171 } /* Generic.Output */
+.highlight .gp { color: #000080; font-weight: bold } /* Generic.Prompt */
+.highlight .gs { font-weight: bold } /* Generic.Strong */
+.highlight .gu { color: #800080; font-weight: bold } /* Generic.Subheading */
+.highlight .gt { color: #04D } /* Generic.Traceback */
+.highlight .kc { color: #008000; font-weight: bold } /* Keyword.Constant */
+.highlight .kd { color: #008000; font-weight: bold } /* Keyword.Declaration */
+.highlight .kn { color: #008000; font-weight: bold } /* Keyword.Namespace */
+.highlight .kp { color: #008000 } /* Keyword.Pseudo */
+.highlight .kr { color: #008000; font-weight: bold } /* Keyword.Reserved */
+.highlight .kt { color: #B00040 } /* Keyword.Type */
+.highlight .m { color: #666 } /* Literal.Number */
+.highlight .s { color: #BA2121 } /* Literal.String */
+.highlight .na { color: #687822 } /* Name.Attribute */
+.highlight .nb { color: #008000 } /* Name.Builtin */
+.highlight .nc { color: #00F; font-weight: bold } /* Name.Class */
+.highlight .no { color: #800 } /* Name.Constant */
+.highlight .nd { color: #A2F } /* Name.Decorator */
+.highlight .ni { color: #717171; font-weight: bold } /* Name.Entity */
+.highlight .ne { color: #CB3F38; font-weight: bold } /* Name.Exception */
+.highlight .nf { color: #00F } /* Name.Function */
+.highlight .nl { color: #767600 } /* Name.Label */
+.highlight .nn { color: #00F; font-weight: bold } /* Name.Namespace */
+.highlight .nt { color: #008000; font-weight: bold } /* Name.Tag */
+.highlight .nv { color: #19177C } /* Name.Variable */
+.highlight .ow { color: #A2F; font-weight: bold } /* Operator.Word */
+.highlight .w { color: #BBB } /* Text.Whitespace */
+.highlight .mb { color: #666 } /* Literal.Number.Bin */
+.highlight .mf { color: #666 } /* Literal.Number.Float */
+.highlight .mh { color: #666 } /* Literal.Number.Hex */
+.highlight .mi { color: #666 } /* Literal.Number.Integer */
+.highlight .mo { color: #666 } /* Literal.Number.Oct */
+.highlight .sa { color: #BA2121 } /* Literal.String.Affix */
+.highlight .sb { color: #BA2121 } /* Literal.String.Backtick */
+.highlight .sc { color: #BA2121 } /* Literal.String.Char */
+.highlight .dl { color: #BA2121 } /* Literal.String.Delimiter */
+.highlight .sd { color: #BA2121; font-style: italic } /* Literal.String.Doc */
+.highlight .s2 { color: #BA2121 } /* Literal.String.Double */
+.highlight .se { color: #AA5D1F; font-weight: bold } /* Literal.String.Escape */
+.highlight .sh { color: #BA2121 } /* Literal.String.Heredoc */
+.highlight .si { color: #A45A77; font-weight: bold } /* Literal.String.Interpol */
+.highlight .sx { color: #008000 } /* Literal.String.Other */
+.highlight .sr { color: #A45A77 } /* Literal.String.Regex */
+.highlight .s1 { color: #BA2121 } /* Literal.String.Single */
+.highlight .ss { color: #19177C } /* Literal.String.Symbol */
+.highlight .bp { color: #008000 } /* Name.Builtin.Pseudo */
+.highlight .fm { color: #00F } /* Name.Function.Magic */
+.highlight .vc { color: #19177C } /* Name.Variable.Class */
+.highlight .vg { color: #19177C } /* Name.Variable.Global */
+.highlight .vi { color: #19177C } /* Name.Variable.Instance */
+.highlight .vm { color: #19177C } /* Name.Variable.Magic */
+.highlight .il { color: #666 } /* Literal.Number.Integer.Long */

--- a/doc/css/style.css
+++ b/doc/css/style.css
@@ -24,7 +24,6 @@ pre {
     padding: 1rem;
     box-shadow: 0.1rem 0.2rem 0.2rem rgba(0, 0, 0, 0.1);
     font-size: 1rem;
-    background-color: var(--bs-gray-100);
 }
 
 footer {

--- a/doc/get_pygments_stylesheet.py
+++ b/doc/get_pygments_stylesheet.py
@@ -1,0 +1,10 @@
+"""
+Generate a pygments CSS stylesheet.
+"""
+import pathlib
+import pygments.formatters
+
+
+css = pygments.formatters.HtmlFormatter(style="default").get_style_defs('.highlight')
+output = pathlib.Path("css") / "pygments.css"
+output.write_text(css)

--- a/nene/_api.py
+++ b/nene/_api.py
@@ -12,7 +12,13 @@ import livereload
 from .crawling import crawl
 from .parsing import load_config, load_data, load_jupyter_notebook, load_markdown
 from .printing import make_console, print_dict, print_file_stats
-from .rendering import make_jinja_envs, markdown_to_html, render_markdown, render_output
+from .rendering import (
+    make_jinja_envs,
+    make_markdown_parser,
+    markdown_to_html,
+    render_markdown,
+    render_output,
+)
 from .utils import capture_build_info
 
 
@@ -188,11 +194,13 @@ def render(site, config, build, console=None, style=""):
         console.print(f"   {page['source']}")
         page["markdown"] = render_markdown(page, config, site, build, jinja_envs)
 
+    parser = make_markdown_parser()
+
     console.print(":art: Converting Markdown content to HTML:", style=style)
     for page in site.values():
         if "markdown" in page:
             console.print(f"   {page['source']}")
-            page["body"] = markdown_to_html(page)
+            page["body"] = markdown_to_html(page, parser)
 
     console.print(":art: Rendering templates for final outputs:", style=style)
     for page in site.values():

--- a/nene/rendering.py
+++ b/nene/rendering.py
@@ -6,9 +6,13 @@ import os
 from pathlib import Path
 
 import jinja2
+import markdown_it
+import markdown_it.common.utils
 import mdit_py_plugins.anchors
 import mdit_py_plugins.footnote
-from markdown_it import MarkdownIt
+import pygments
+import pygments.formatters
+import pygments.lexers
 
 
 def filter_relative_to(path, start):
@@ -81,22 +85,12 @@ def make_jinja_envs(templates_dir):
     return envs
 
 
-def markdown_to_html(page):
+def make_markdown_parser():
     """
-    Convert the Markdown content of a page to HTML.
-
-    Parameters
-    ----------
-    page : dict
-        Dictionary with the parsed YAML front-matter and Markdown body.
-
-    Returns
-    -------
-    html : str
-        The converted HTML.
-
+    Create the Markdown-it-py parser object that can generate HTML.
     """
-    parser = MarkdownIt("commonmark", {"typographer": True})
+    parser = markdown_it.MarkdownIt("commonmark", {"typographer": True,
+                                                   "highlight": _highlight_code})
     parser.enable(["replacements", "smartquotes"])
     parser.enable("table")
     parser.use(mdit_py_plugins.anchors.anchors_plugin)
@@ -104,8 +98,8 @@ def markdown_to_html(page):
     # Remove the starting hr from the footnote block. It's ugly and should be
     # handled through CSS by putting a top border on section element.
     parser.add_render_rule("footnote_block_open", _render_footnote_block_open)
-    html = parser.render(page["markdown"])
-    return html
+    parser.add_render_rule("fence", _render_code)
+    return parser
 
 
 def _render_footnote_block_open(self, tokens, idx, options, env):
@@ -117,6 +111,59 @@ def _render_footnote_block_open(self, tokens, idx, options, env):
     if lines[0].strip().startswith("<hr"):
         lines = lines[1:]
     return "\n".join(lines)
+
+
+# This code is based on code from a comment on a markdown-it-py issue:
+# https://github.com/executablebooks/markdown-it-py/issues/256#issuecomment-2937277893
+########################################################################################
+def _highlight_code(code, name, attrs):
+    """Use pygments to highlight the code."""
+    if name == "":
+        return None
+    lexer = pygments.lexers.get_lexer_by_name(name)
+    formatter = pygments.formatters.HtmlFormatter()
+    return pygments.highlight(code, lexer, formatter)
+
+
+def _render_code(self, tokens, idx, options, env):
+    """Custom rule to highlight the code when rendering it."""
+    token = tokens[idx]
+    info = (
+        markdown_it.common.utils.unescapeAll(token.info).strip() if token.info else ""
+    )
+    langName = info.split(maxsplit=1)[0] if info else ""
+    if options.highlight:
+        return (
+            options.highlight(token.content, langName, "")
+            or f"<pre><code>{markdown_it.common.utils.escapeHtml(token.content)}</code></pre>"
+        )
+    return (
+        f"<pre><code>{markdown_it.common.utils.escapeHtml(token.content)}</code></pre>"
+    )
+
+
+########################################################################################
+
+
+def markdown_to_html(page, parser):
+    """
+    Convert the Markdown content of a page to HTML.
+
+    Parameters
+    ----------
+    page : dict
+        Dictionary with the parsed YAML front-matter and Markdown body.
+    parser : MarkdownIt
+        A Markdown-it-py parser.
+
+    Returns
+    -------
+    html : str
+        The converted HTML.
+
+    """
+    html = parser.render(page["markdown"])
+    return html
 
 
 def render_markdown(page, config, site, build, jinja_envs):

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ install_requires =
     livereload>=2.6
     click>=8
     rich>=10.9
+    pygments>=2.17
 
 [options.extras_require]
 jupyter =


### PR DESCRIPTION
Runs the highlighter code on code blocks using the solution from https://github.com/executablebooks/markdown-it-py/issues/256#issuecomment-2937277893 Doesn't add the stylesheet automatically. For highlighting to actually show up, users need to generate the pygments stylesheets (see example in the doc folder) and add it to the HTML.